### PR TITLE
#162948976 Users should be able to see their reading statistics

### DIFF
--- a/src/assets/styles/articles.scss
+++ b/src/assets/styles/articles.scss
@@ -63,3 +63,25 @@
   text-decoration: none;
   color: #000000;
 }
+
+.article-views {
+  font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
+  font-size: 15px;
+  font-weight: bolder;
+}
+
+.article-body {
+  font-size: 13px;
+}
+
+.article-body p {
+  width: 100%
+}
+
+.article-body h2 {
+  text-align: center;
+}
+
+.body-img {
+  width: 350px;
+}

--- a/src/components/articles/AllArticles.jsx
+++ b/src/components/articles/AllArticles.jsx
@@ -61,11 +61,11 @@ class AllArticles extends Component {
                     like={article.likes}
                     dislike={article.dislikes}
                     rating={article.avg_rating.avg_rating}
+                    views={article.views}
                   />
                 ))}
               </div>
             )}
-          
             {articles.article.count > config.PAGE_SIZE && (
               <div className="mx-auto">
                 <Pagination

--- a/src/components/articles/Article.jsx
+++ b/src/components/articles/Article.jsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { Link } from "react-router-dom";
-import "../../assets/styles/articles.scss";
+import React from 'react';
+import { Link } from 'react-router-dom';
+import '../../assets/styles/articles.scss';
 
 import pen from '../../assets/images/pen.jpg';
 import AllArticlesDisplayRating from '../rating/AllArticlesDisplayRating';
@@ -46,20 +46,35 @@ const Article = article => (
                   className="logo w-100 h-100 mx-3"
                 />
               )) || (
-                <img src={pen} alt="logo" className="logo w-100 h-100 mx-3" />
-              )}
+                  <img src={pen} alt="logo" className="logo w-100 h-100 mx-3" />
+                )}
             </div>
             <div className="col col-md-5">{article.description}</div>
           </div>
         </div>
       </Link>
       <hr />
-      <div className="likecontainer">
-        <i className="fa fa-thumbs-up fa-2x thumbsup" id="thumbsup" /> {article.like}{' '}
-        &nbsp;&nbsp;&nbsp; <i className="fa fa-thumbs-down fa-2x thumbsdown" id="thumbsdown" />{' '}
-        {article.dislike}
+      <div className="row likecontainer">
+        <div className="col-sm-2">
+          <i className="fa fa-thumbs-up fa-2x thumbsup" id="thumbsup" /> {article.like}{' '}
+          &nbsp;&nbsp;&nbsp; <i className="fa fa-thumbs-down fa-2x thumbsdown" id="thumbsdown" />{' '}
+          {article.dislike}
+        </div>
+        <div className="col-sm-2">
+          <AllArticlesDisplayRating {...article} />
+        </div>
+        <div className="article-views">
+          <div className="article-views">
+            <i className="glyphicon glyphicon-eye-open d-inline text-primary"></i>
+            <div className="views-count pl-2 d-inline">
+              {article.views} 
+            </div>  
+            <div className="pl-1 d-inline font-weight-normal">
+              Views
+            </div>
+          </div>
+        </div>
       </div>
-      <AllArticlesDisplayRating {...article} />
     </div>
   </div>
 );

--- a/src/components/articles/SingleArticle.jsx
+++ b/src/components/articles/SingleArticle.jsx
@@ -11,9 +11,7 @@ import DisplayRating from '../rating/DisplayRating';
 import { getSingleArticle, deleteArticle } from '../../actions/articleActions';
 import LikesDislikes from './LikeDislikeArticle';
 import launchToast from '../../helpers/toaster';
-import NotFound from '../layout/NotFound';
 import '../../assets/styles/articles.scss';
-import ShareArticle from '../socialshare/ShareArticle';
 
 class SingleArticle extends Component {
   // eslint-disable-next-line react/no-unused-state
@@ -28,10 +26,13 @@ class SingleArticle extends Component {
 
   buttonDeleteArticle = () => {
     const slug = this.props.article.article.slug;
-    this.props.deleteArticle(slug);
-    launchToast('Article Deleted', 'toastSuccess', 'descSuccess', 'success');
-    this.props.history.push('/');
-    window.location.reload();
+    const confirmDelete = window.confirm("Are you sure you want to Delete?");
+    if (confirmDelete) {
+      this.props.deleteArticle(slug);
+      launchToast("Article Deleted", "toastSuccess", "descSuccess", "success");
+      this.props.history.push('/');
+      window.location.reload();
+    } 
   };
 
   checkLoggedInUser = () => {
@@ -67,14 +68,18 @@ class SingleArticle extends Component {
     return (
       <React.Fragment>
         <div>
-          {notFetching ? (
+          {notFetching && (
             <div>
               <div className="container mt-3">
-                <div className="container card border border-dark  bg-light">
+                <div className="container card border border-dark bg-light">
                   <div className="card-header border-0 bg-light">
                     <div className="row  border border-dark border-top-0 border-right-0 border-left-0">
-                      <div className="col col-sm-1">
-                        <img src={article.article.author.image} alt="" className="rounded-circle w-75 border ml-2" />
+                      <div className="col-sm-1">
+                        <img
+                          src={article.article.author.image}
+                          alt=""
+                          className="rounded-circle w-75 border ml-2"
+                        />
                       </div>
                       <div>
                         <span className="font-weight-bold">{article.article.author.username}</span>
@@ -91,18 +96,29 @@ class SingleArticle extends Component {
                       <span>Avg rating</span>
                       <DisplayRating {...this.props} />
                       <div className="row">
-                        <div className="col col-md-5">
+                        <div className="col-md-12 pt-3 article-body">
                           {article.article.image_url && (
-                            <img src={article.article.image_url} alt="ArticleImage" className="logo w-100 h-100 mx-3" />
+                            <div className="pull-left body-img">
+                              <img
+                                src={article.article.image_url}
+                                alt="ArticleImage"
+                                className="img-responsive pull-left pr-3 pb-3"
+                              />
+                            </div>
                           )}
+                          {ReactHtmlParser(article.article.body)}
                         </div>
-                        <div className="col col-md-5">{ReactHtmlParser(article.article.body)}</div>
                       </div>
-                      <div className="row">
-                        <div className="col col-md-4">
-                          {Auth.isAuthenticated ? (
-                            <LikesDislikes {...this.props} />
-                          ) : (
+                    </div>
+                    <hr />
+                    <div className="row pt-3">
+                      <div className="col-sm-3 article-views">
+                        {this.checkLoggedInUser()}
+                      </div>
+                      <div className="col-sm-2 d-inline">
+                        {Auth.isAuthenticated ? (
+                          <LikesDislikes {...this.props} />
+                        ) : (
                             <div className="likecontainer">
                               <i className="fa fa-thumbs-up fa-2x " />
                               {article.article.likes}
@@ -112,23 +128,30 @@ class SingleArticle extends Component {
                               {article.article.dislikes}
                             </div>
                           )}
+                      </div>
+                      <div className="col-sm-2 d-inline">
+                        {Auth.isAuthenticated && <Rating {...this.props} />}
+                      </div>
+                      <div className="col-sm-3">
+                        <i className="glyphicon glyphicon-eye-open ml-2  d-inline text-primary"></i>
+                        <div className="views-count ml-2 d-inline">
+                          {article.article.views}
+                        </div>
+                        <div className="pl-1 d-inline font-weight-normal">
+                          Views
                         </div>
                       </div>
-                      <div className="col col-md-4">{Auth.isAuthenticated && <Rating {...this.props} />}</div>
+                      <div className="col-sm-2">
+                        <BookmarkArticle {...this.props} />
+                      </div>
                     </div>
-                    {this.checkLoggedInUser()}
-                  </div>
                   <div />
-                  <BookmarkArticle {...this.props} />
-                </div>
-                <br />
-                <ShareArticle {...this.props} />
+                  </div>
+                  </div>
                 <CommentsContainer {...this.props} />
                 <div className="card-footer bg-light" />
               </div>
             </div>
-          ) : (
-            <NotFound />
           )}
         </div>
       </React.Fragment>

--- a/src/components/articles/__test__/article.test.js
+++ b/src/components/articles/__test__/article.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import BookmarkArticle from '../boomarks/Bookmark';
+import SingleArticle from '../SingleArticle';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+function setup() {
+    const props = {
+        article: jest.fn(),
+    };
+    const wrapper = shallow(<SingleArticle />);
+
+    return {
+        props,
+        wrapper,
+    };
+}
+
+describe('Articles', () => {
+    it('render elements to a single articles', () => {
+        const { wrapper } = setup();
+        expect(wrapper).toBeDefined();
+    });
+    it('render the aricle view icon', () => {
+        const { wrapper } = setup();
+        const icon = wrapper.find('.article-views');
+        expect(icon).toBeDefined();
+    });
+});

--- a/src/components/articles/boomarks/bookmark.scss
+++ b/src/components/articles/boomarks/bookmark.scss
@@ -1,7 +1,6 @@
 .bookmark {
   border: 0;
   float: right;
-  margin: 15px;
 }
 
 #bookmark {

--- a/src/components/comments/Comments.jsx
+++ b/src/components/comments/Comments.jsx
@@ -37,9 +37,9 @@ export class Comments extends Component {
 }
 
 Comments.propTypes = {
-  comments: PropTypes.array.isRequired,
+  comments: PropTypes.object.isRequired,
   getComments: PropTypes.func.isRequired,
-  match: PropTypes.string,
+  match: PropTypes.object,
   slug: PropTypes.string,
 };
 

--- a/src/components/comments/CommentsContainer.jsx
+++ b/src/components/comments/CommentsContainer.jsx
@@ -49,9 +49,25 @@ class CommentsContainer extends Component {
 
   render() {
     const { comments, errors } = this.state;
+    const {
+      comments: {
+        comments: {
+          count,
+        },
+      },
+    } = this.props;
     return (
       <div>
-        <h1>Comments</h1>
+        <div className="row">
+          <div className=" col-md-10 text-center">
+            <h1>Comments</h1>
+          </div>
+          <div className="col-md-2 comments-count mt-3 text-center font-weight-bolder">
+            {/* eslint-disable-next-line react/prop-types */}
+            {count}
+            <div className="d-inline ml-2">Comments</div>
+          </div>
+        </div>
         <hr />
         <Comments {...this.props} />
         {Auth.isAuthenticated && (
@@ -73,6 +89,7 @@ CommentsContainer.propTypes = {
   addComment: PropTypes.func.isRequired,
   slug: PropTypes.string,
   match: PropTypes.string,
+  comments: PropTypes.number,
 };
 
 const mapStateToProps = state => ({

--- a/src/components/comments/__test__/allComments.test.js
+++ b/src/components/comments/__test__/allComments.test.js
@@ -47,3 +47,9 @@ describe('Comments elements tests', () => {
     expect(wrapper.find(Comment).length).toBe(2);
   });
 });
+
+it('render comments count ', () => {
+  const { wrapper } = setup();
+  const comments = wrapper.find('.comments-count');
+  expect(comments).toBeDefined();
+});

--- a/src/components/navBar.jsx
+++ b/src/components/navBar.jsx
@@ -64,7 +64,6 @@ const NavBar = () => (
                   My Profile
                 </Link>
                 )}
-    
                 <Link
                   className="dropdown-item menu-dropdown-item"
                   to="/article/create-article"

--- a/src/components/rating/RatingArticle.jsx
+++ b/src/components/rating/RatingArticle.jsx
@@ -15,18 +15,16 @@ class Rating extends Component {
   render() {
     return (
       <React.Fragment>
-        <div className="mt-5">
-          <span>Rate this article</span>
-          <br />
-          <StarRatingComponent
-            name="rateArticle"
-            starCount={5}
-            onStarClick={this.onStarClick}
-          />
-          {this.props.isLoading && (
-            <i className="fas fa-spinner fa-spin ml-2" />
-          )}
-        </div>
+        <span>Rate this article</span>
+        <br />
+        <StarRatingComponent
+          name="rateArticle"
+          starCount={5}
+          onStarClick={this.onStarClick}
+        />
+        {this.props.isLoading && (
+          <i className="fas fa-spinner fa-spin ml-2" />
+        )}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
#### What does this PR do?
Allows any user to see their reading statistics

#### Description of Task to be completed?
- Shows  total number of comments on every article
- Shows total number on the article views
- Restructure on the single article fonts and alignment of image and article body

#### How should this be manually tested?
Clone this repo, cd into it, do `npm install`, run tests by `npm test`, start the server `npm start`. On the home route, you can see the number of views per article and on opening a single article, you can view the number of comments

#### What are the relevant pivotal tracker stories?
[#162948976](https://www.pivotaltracker.com/story/show/162948976)

#### Screenshots 
##### Number of Views
<img width="584" alt="screen shot 2019-02-26 at 15 19 07" src="https://user-images.githubusercontent.com/25298492/53412263-f0136480-39d9-11e9-89cf-1fe48c9c436b.png">


##### Number of comments
<img width="1133" alt="screen shot 2019-02-26 at 15 19 17" src="https://user-images.githubusercontent.com/25298492/53412294-04eff800-39da-11e9-9083-cf152dc4e2ff.png">




